### PR TITLE
Fixes stackoverflow running moderneJar

### DIFF
--- a/model/src/main/java/org/openrewrite/gradle/marker/GradleProjectBuilder.java
+++ b/model/src/main/java/org/openrewrite/gradle/marker/GradleProjectBuilder.java
@@ -250,16 +250,18 @@ public final class GradleProjectBuilder {
         ResolvedGroupArtifactVersion resolvedGav = resolvedGroupArtifactVersion(dep);
         org.openrewrite.maven.tree.ResolvedDependency resolvedDependency = resolvedCache.get(resolvedGav);
         if(resolvedDependency == null) {
+
+            List<org.openrewrite.maven.tree.ResolvedDependency> dependencies = new ArrayList<>();
+
             resolvedDependency = org.openrewrite.maven.tree.ResolvedDependency.builder()
                     .gav(resolvedGav)
                     .requested(dependency(dep))
-                    .dependencies(dep.getChildren().stream()
-                            .map(child -> resolved(child, depth + 1, resolvedCache))
-                            .collect(toList()))
+                    .dependencies(dependencies)
                     .licenses(emptyList())
-                    .depth(depth)
-                    .build();
+                    .depth(depth).build();
+            //we add a temporal resolved dependency in the cache to avoid stackoverflow with dependencies that have cycles
             resolvedCache.put(resolvedGav, resolvedDependency);
+            dep.getChildren().forEach(child -> dependencies.add(resolved(child, depth + 1, resolvedCache)));
         }
         return resolvedDependency;
     }


### PR DESCRIPTION
This is the log message produced:
```
org.gradle.internal.concurrent.ManagedExecutorImpl$1.run(ManagedExecutorImpl.java:49) Caused by: java.lang.StackOverflowError
    at org.openrewrite.gradle.marker.GradleProjectBuilder.resolved(GradleProjectBuilder.java:250)
    at org.openrewrite.gradle.marker.GradleProjectBuilder.lambda$resolved$17(GradleProjectBuilder.java:257)
    at org.openrewrite.gradle.marker.GradleProjectBuilder.resolved(GradleProjectBuilder.java:258)
    at org.openrewrite.gradle.marker.GradleProjectBuilder.lambda$resolved$17(GradleProjectBuilder.java:257)
    at org.openrewrite.gradle.marker.GradleProjectBuilder.resolved(GradleProjectBuilder.java:258)
    at org.openrewrite.gradle.marker.GradleProjectBuilder.lambda$resolved$17(GradleProjectBuilder.java:257)
    at org.openrewrite.gradle.marker.GradleProjectBuilder.resolved(GradleProjectBuilder.java:258)
    at org.openrewrite.gradle.marker.GradleProjectBuilder.lambda$resolved$17(GradleProjectBuilder.java:257)
    at org.openrewrite.gradle.marker.GradleProjectBuilder.resolved(GradleProjectBuilder.java:258)
    at org.openrewrite.gradle.marker.GradleProjectBuilder.lambda$resolved$17(GradleProjectBuilder.java:257)
    at org.openrewrite.gradle.marker.GradleProjectBuilder.resolved(GradleProjectBuilder.java:258)
```
Since it is unclear how to reproduce a dependency tree that produces a cycle, I have tested this change has been locally tested with openrewrite-gradle running.