### PR TITLE
Resolve and return transitive dependencies from getResolved()

### DIFF
--- a/model/src/main/java/org/openrewrite/gradle/marker/GradleProjectBuilder.java
+++ b/model/src/main/java/org/openrewrite/gradle/marker/GradleProjectBuilder.java
@@ -40,6 +40,7 @@ import java.util.stream.Collectors;
 
 import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.toList;
+import static org.openrewrite.gradle.marker.GradleDependencyConfiguration.resolveTransitiveDependencies;
 import static org.openrewrite.gradle.marker.GradleSettingsBuilder.GRADLE_PLUGIN_PORTAL;
 
 public final class GradleProjectBuilder {
@@ -175,12 +176,13 @@ public final class GradleProjectBuilder {
                 } else {
                     resolved = emptyList();
                 }
+                List<org.openrewrite.maven.tree.ResolvedDependency> transitive = resolveTransitiveDependencies(resolved, new LinkedHashSet<>());
                 GradleDependencyConfiguration dc = new GradleDependencyConfiguration(conf.getName(), conf.getDescription(),
-                        conf.isTransitive(), conf.isCanBeResolved(), conf.isCanBeConsumed(), emptyList(), requested, resolved, null, null);
+                        conf.isTransitive(), conf.isCanBeResolved(), conf.isCanBeConsumed(), emptyList(), requested, resolved, transitive, null, null);
                 results.put(conf.getName(), dc);
             } catch (Exception e) {
                 GradleDependencyConfiguration dc = new GradleDependencyConfiguration(conf.getName(), conf.getDescription(),
-                        conf.isTransitive(), conf.isCanBeResolved(), conf.isCanBeConsumed(), emptyList(), emptyList(), emptyList(), e.getClass().getName(), e.getMessage());
+                        conf.isTransitive(), conf.isCanBeResolved(), conf.isCanBeConsumed(), emptyList(), emptyList(), emptyList(), emptyList(), e.getClass().getName(), e.getMessage());
                 results.put(conf.getName(), dc);
             }
         }

--- a/model/src/main/java/org/openrewrite/gradle/toolingapi/GradleDependencyConfiguration.java
+++ b/model/src/main/java/org/openrewrite/gradle/toolingapi/GradleDependencyConfiguration.java
@@ -32,5 +32,7 @@ public interface GradleDependencyConfiguration {
 
     List<Dependency> getRequested();
 
+    List<ResolvedDependency> getDirectResolved();
+
     List<ResolvedDependency> getResolved();
 }


### PR DESCRIPTION
## What's changed?
Make a distinction between direct and transitive dependencies are returned from the GradleDependencyConfiguration.

## What's your motivation?
When detecting dependencies or vulnerabilities, folks most likely want all dependencies, rather than just the direct dependencies. We would not want every recipe to have to recurse over a hierarchy of dependencies.

## Anything in particular you'd like reviewers to focus on?
- [ ] Went for `LinkedHashSet` to maintain a predictable order, at the expense of performance. Is that OK?
- [x] Added an explicit constructor, even though Lombok also generates it's own all args constructor; is that OK?
- [ ] Figured resolve the transitive dependencies once from a constructor, rather than leave that up to the caller; ok?
- [ ] Didn't see any tests in the project; OK to continue without?

## Anyone you would like to review specifically?
@sambsnyd 

## Have you considered any alternatives or workarounds?
- Could have added a `getAllResolved` or `getTransitiveResolved` instead; if we want to keep behavior as it was.

## Any additional context
- [DependencyVulnerabilityCheck calls getResolved()](https://github.com/openrewrite/rewrite-java-dependencies/blob/9d483fbdb2ca880d5b297b0c41be607df076471f/src/main/java/org/openrewrite/java/dependencies/DependencyVulnerabilityCheck.java#L275) but only got direct dependencies up to now.
- There's a few other callers of `getResolved()`: https://github.com/search?q=org%3Aopenrewrite%20getResolved()&type=code