### PR TITLE
Abort test on failure to load Gradle tooling API

### DIFF
--- a/model/src/main/java/org/openrewrite/gradle/toolingapi/OpenRewriteModelBuilder.java
+++ b/model/src/main/java/org/openrewrite/gradle/toolingapi/OpenRewriteModelBuilder.java
@@ -20,6 +20,7 @@ import org.gradle.tooling.ModelBuilder;
 import org.gradle.tooling.ProjectConnection;
 import org.gradle.tooling.internal.consumer.DefaultGradleConnector;
 import org.jspecify.annotations.Nullable;
+import org.opentest4j.TestAbortedException;
 
 import java.io.File;
 import java.io.IOException;
@@ -105,7 +106,7 @@ public class OpenRewriteModelBuilder {
                 customModelBuilder.withArguments(arguments);
                 return customModelBuilder.get();
             } catch (IOException e) {
-                throw new UncheckedIOException(e);
+                throw new TestAbortedException("Failed to load Gradle tooling API", e);
             } finally {
                 try {
                     Files.delete(init);


### PR DESCRIPTION
With this change tests are now skipped, as opposed to failing. This then allows other tests to run in restricted environments, while still providing a clear indication that the Gradle related tests did not run.

Otherwise folks would have seen failures like:
```
AddJaxbDependenciesTest > renameRuntime() FAILED
    java.lang.RuntimeException: org.gradle.tooling.GradleConnectionException: Could not install Gradle distribution from 'https://services.gradle.org/distributions/gradle-8.4-bin.zip'.
        at org.openrewrite.test.UncheckedConsumer.accept(UncheckedConsumer.java:29)
        at org.openrewrite.test.RewriteTest.rewriteRun(RewriteTest.java:345)
        at org.openrewrite.test.RewriteTest.rewriteRun(RewriteTest.java:132)
        at org.openrewrite.java.migrate.javax.AddJaxbDependenciesTest.renameRuntime(AddJaxbDependenciesTest.java:153)

        Caused by:
        org.gradle.tooling.GradleConnectionException: Could not install Gradle distribution from 'https://services.gradle.org/distributions/gradle-8.4-bin.zip'.
            at org.gradle.tooling.internal.consumer.DistributionFactory$ZippedDistribution.getToolingImplementationClasspath(DistributionFactory.java:135)
            at org.gradle.tooling.internal.consumer.loader.CachingToolingImplementationLoader.create(CachingToolingImplementationLoader.java:47)
            at org.gradle.tooling.internal.consumer.loader.SynchronizedToolingImplementationLoader.create(SynchronizedToolingImplementationLoader.java:44)
            at org.gradle.tooling.internal.consumer.connection.LazyConsumerActionExecutor.onStartAction(LazyConsumerActionExecutor.java:160)
            at org.gradle.tooling.internal.consumer.connection.LazyConsumerActionExecutor.run(LazyConsumerActionExecutor.java:142)
            at org.gradle.tooling.internal.consumer.connection.CancellableConsumerActionExecutor.run(CancellableConsumerActionExecutor.java:45)
            at org.gradle.tooling.internal.consumer.connection.ProgressLoggingConsumerActionExecutor.run(ProgressLoggingConsumerActionExecutor.java:61)
            at org.gradle.tooling.internal.consumer.connection.RethrowingErrorsConsumerActionExecutor.run(RethrowingErrorsConsumerActionExecutor.java:38)
            at org.gradle.tooling.internal.consumer.async.DefaultAsyncConsumerActionExecutor$1$1.run(DefaultAsyncConsumerActionExecutor.java:66)
            at org.gradle.internal.concurrent.ExecutorPolicy$CatchAndRecordFailures.onExecute(ExecutorPolicy.java:64)
            at org.gradle.internal.concurrent.AbstractManagedExecutor$1.run(AbstractManagedExecutor.java:48)
            at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
            at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
            at java.base/java.lang.Thread.run(Thread.java:840)
            at org.gradle.tooling.internal.consumer.BlockingResultHandler.getResult(BlockingResultHandler.java:46)
            at org.gradle.tooling.internal.consumer.DefaultModelBuilder.get(DefaultModelBuilder.java:50)
            at org.openrewrite.gradle.toolingapi.OpenRewriteModelBuilder.forProjectDirectory(OpenRewriteModelBuilder.java:106)
            at org.openrewrite.gradle.toolingapi.Assertions.lambda$withToolingApi$0(Assertions.java:122)
            at org.openrewrite.gradle.toolingapi.Assertions$$Lambda$972/0x000000c00156f6f0.acceptThrows(Unknown Source)
            at org.openrewrite.test.UncheckedConsumer.accept(UncheckedConsumer.java:27)
            ... 3 more

            Caused by:
            java.io.IOException: Downloading from https://services.gradle.org/distributions/gradle-8.4-bin.zip failed: timeout (10000ms)
                at org.gradle.wrapper.Download.downloadInternal(Download.java:152)
                at org.gradle.wrapper.Download.download(Download.java:110)
                at org.gradle.tooling.internal.consumer.DistributionInstaller$AsyncDownload$1.run(DistributionInstaller.java:182)

                Caused by:
                java.net.SocketTimeoutException: Connect timed out
                    at java.base/sun.nio.ch.NioSocketImpl.timedFinishConnect(NioSocketImpl.java:551)
                    at java.base/sun.nio.ch.NioSocketImpl.connect(NioSocketImpl.java:602)
                    at java.base/java.net.SocksSocketImpl.connect(SocksSocketImpl.java:327)
                    at java.base/java.net.Socket.connect(Socket.java:639)
                    at java.base/sun.security.ssl.SSLSocketImpl.connect(SSLSocketImpl.java:304)
                    at java.base/sun.net.NetworkClient.doConnect(NetworkClient.java:178)
                    at java.base/sun.net.www.http.HttpClient.openServer(HttpClient.java:533)
                    at java.base/sun.net.www.http.HttpClient.openServer(HttpClient.java:638)
                    at java.base/sun.net.www.protocol.https.HttpsClient.<init>(HttpsClient.java:266)
                    at java.base/sun.net.www.protocol.https.HttpsClient.New(HttpsClient.java:380)
                    at java.base/sun.net.www.protocol.https.AbstractDelegateHttpsURLConnection.getNewHttpClient(AbstractDelegateHttpsURLConnection.java:193)
                    at java.base/sun.net.www.protocol.http.HttpURLConnection.plainConnect0(HttpURLConnection.java:1245)
                    at java.base/sun.net.www.protocol.http.HttpURLConnection.plainConnect(HttpURLConnection.java:1131)
                    at java.base/sun.net.www.protocol.https.AbstractDelegateHttpsURLConnection.connect(AbstractDelegateHttpsURLConnection.java:179)
                    at java.base/sun.net.www.protocol.http.HttpURLConnection.getInputStream0(HttpURLConnection.java:1690)
                    at java.base/sun.net.www.protocol.http.HttpURLConnection.getInputStream(HttpURLConnection.java:1614)
                    at java.base/sun.net.www.protocol.https.HttpsURLConnectionImpl.getInputStream(HttpsURLConnectionImpl.java:224)
                    at org.gradle.wrapper.Download.downloadInternal(Download.java:130)
                    ... 2 more
```