### PR TITLE
Use Gradle version 8.12 when none is specified

### DIFF
--- a/model/src/main/java/org/openrewrite/gradle/toolingapi/OpenRewriteModelBuilder.java
+++ b/model/src/main/java/org/openrewrite/gradle/toolingapi/OpenRewriteModelBuilder.java
@@ -80,7 +80,7 @@ public class OpenRewriteModelBuilder {
         if (Files.exists(projectDir.toPath().resolve("gradle/wrapper/gradle-wrapper.properties"))) {
             connector.useBuildDistribution();
         } else {
-            connector.useGradleVersion("8.4");
+            connector.useGradleVersion("8.12");
         }
         connector.forProjectDirectory(projectDir);
         List<String> arguments = new ArrayList<>();


### PR DESCRIPTION
Before this we used 8.4, for which I'm seeing download failures downstream when running tests.