### PR TITLE
Support for --offline

### DIFF
--- a/model/src/main/java/org/openrewrite/gradle/toolingapi/Assertions.java
+++ b/model/src/main/java/org/openrewrite/gradle/toolingapi/Assertions.java
@@ -63,6 +63,10 @@ public class Assertions {
     }
 
     public static UncheckedConsumer<List<SourceFile>> withToolingApi(@Nullable GradleWrapper gradleWrapper, @Nullable String initScriptContents) {
+        return withToolingApi(gradleWrapper, initScriptContents, false);
+    }
+
+    public static UncheckedConsumer<List<SourceFile>> withToolingApi(@Nullable GradleWrapper gradleWrapper, @Nullable String initScriptContents, boolean offline) {
         return sourceFiles -> {
             try {
                 Path tempDirectory = Files.createTempDirectory("project");
@@ -120,14 +124,14 @@ public class Assertions {
                     for (int i = 0; i < sourceFiles.size(); i++) {
                         SourceFile sourceFile = sourceFiles.get(i);
                         if (sourceFile.getSourcePath().endsWith("settings.gradle")) {
-                            OpenRewriteModel model = OpenRewriteModelBuilder.forProjectDirectory(tempDirectory.resolve(sourceFile.getSourcePath()).getParent().toFile(), null, initScriptContents);
+                            OpenRewriteModel model = OpenRewriteModelBuilder.forProjectDirectory(tempDirectory.resolve(sourceFile.getSourcePath()).getParent().toFile(), null, initScriptContents, offline);
                             org.openrewrite.gradle.toolingapi.GradleSettings rawSettings = model.gradleSettings();
                             if (rawSettings != null) {
                                 GradleSettings gradleSettings = org.openrewrite.gradle.toolingapi.GradleSettings.toMarker(rawSettings);
                                 sourceFiles.set(i, sourceFile.withMarkers(sourceFile.getMarkers().add(gradleSettings)));
                             }
                         } else if (sourceFile.getSourcePath().endsWith("build.gradle")) {
-                            OpenRewriteModel model = OpenRewriteModelBuilder.forProjectDirectory(projectDir.toFile(), tempDirectory.resolve(sourceFile.getSourcePath()).toFile(), initScriptContents);
+                            OpenRewriteModel model = OpenRewriteModelBuilder.forProjectDirectory(projectDir.toFile(), tempDirectory.resolve(sourceFile.getSourcePath()).toFile(), initScriptContents, offline);
                             GradleProject gradleProject = org.openrewrite.gradle.toolingapi.GradleProject.toMarker(model.gradleProject());
                             allRepositories.addAll(gradleProject.getMavenRepositories());
                             allBuildscriptRepositories.addAll(gradleProject.getBuildscript().getMavenRepositories());
@@ -174,6 +178,10 @@ public class Assertions {
 
     public static UncheckedConsumer<List<SourceFile>> withToolingApi() {
         return withToolingApi((GradleWrapper) null, null);
+    }
+
+    public static UncheckedConsumer<List<SourceFile>> withOfflineToolingApi() {
+        return withToolingApi((GradleWrapper) null, null, true);
     }
 
     private static void deleteDirectory(File directoryToBeDeleted) {

--- a/model/src/main/java/org/openrewrite/gradle/toolingapi/OpenRewriteModelBuilder.java
+++ b/model/src/main/java/org/openrewrite/gradle/toolingapi/OpenRewriteModelBuilder.java
@@ -38,9 +38,21 @@ public class OpenRewriteModelBuilder {
      * Build an OpenRewriteModel for a project directory, using the default Gradle init script bundled within this jar.
      * The included init script accesses public artifact repositories (Maven Central, Nexus Snapshots) to be able to
      * download rewrite dependencies, so public repositories must be accessible for this to work.
+     * @see #forProjectDirectory(File, File, String, boolean)
      */
     public static OpenRewriteModel forProjectDirectory(File projectDir, @Nullable File buildFile) throws IOException {
-        return forProjectDirectory(projectDir, buildFile, null);
+        return forProjectDirectory(projectDir, buildFile, null, false);
+    }
+
+    /**
+     * <b></b>Warning: This API is likely to change over time without notice</b>
+     * Build an OpenRewriteModel for a project directory, using the default Gradle init script bundled within this jar.
+     * The included init script accesses public artifact repositories (Maven Central, Nexus Snapshots) to be able to
+     * download rewrite dependencies, so public repositories must be accessible for this to work.
+     * @see #forProjectDirectory(File, File, String, boolean)
+     */
+    public static OpenRewriteModel forProjectDirectory(File projectDir, @Nullable File buildFile, @Nullable String initScript) throws IOException {
+        return forProjectDirectory(projectDir, buildFile, initScript, false);
     }
 
     /**
@@ -75,7 +87,7 @@ public class OpenRewriteModelBuilder {
      * }
      * </pre>
      */
-    public static OpenRewriteModel forProjectDirectory(File projectDir, @Nullable File buildFile, @Nullable String initScript) throws IOException {
+    public static OpenRewriteModel forProjectDirectory(File projectDir, @Nullable File buildFile, @Nullable String initScript, boolean offline) throws IOException {
         DefaultGradleConnector connector = (DefaultGradleConnector)GradleConnector.newConnector();
         if (Files.exists(projectDir.toPath().resolve("gradle/wrapper/gradle-wrapper.properties"))) {
             connector.useBuildDistribution();
@@ -91,6 +103,11 @@ public class OpenRewriteModelBuilder {
         arguments.add("--init-script");
         Path init = projectDir.toPath().resolve("openrewrite-tooling.gradle").toAbsolutePath();
         arguments.add(init.toString());
+
+        if (offline) {
+            arguments.add("--offline");
+        }
+
         try (ProjectConnection connection = connector.connect()) {
             ModelBuilder<OpenRewriteModel> customModelBuilder = connection.model(OpenRewriteModel.class);
             try {


### PR DESCRIPTION
## What's changed?
Adding support for `--offline` option to `OpenRewriteModelBuilder`.

## What's your motivation?
To speed up Gradle executions in some contexts, i.e. tests.
