### PR TITLE
Revert "Support for --offline"

### DIFF
--- a/model/src/main/java/org/openrewrite/gradle/toolingapi/Assertions.java
+++ b/model/src/main/java/org/openrewrite/gradle/toolingapi/Assertions.java
@@ -63,10 +63,6 @@ public class Assertions {
     }
 
     public static UncheckedConsumer<List<SourceFile>> withToolingApi(@Nullable GradleWrapper gradleWrapper, @Nullable String initScriptContents) {
-        return withToolingApi(gradleWrapper, initScriptContents, false);
-    }
-
-    public static UncheckedConsumer<List<SourceFile>> withToolingApi(@Nullable GradleWrapper gradleWrapper, @Nullable String initScriptContents, boolean offline) {
         return sourceFiles -> {
             try {
                 Path tempDirectory = Files.createTempDirectory("project");
@@ -124,14 +120,14 @@ public class Assertions {
                     for (int i = 0; i < sourceFiles.size(); i++) {
                         SourceFile sourceFile = sourceFiles.get(i);
                         if (sourceFile.getSourcePath().endsWith("settings.gradle")) {
-                            OpenRewriteModel model = OpenRewriteModelBuilder.forProjectDirectory(tempDirectory.resolve(sourceFile.getSourcePath()).getParent().toFile(), null, initScriptContents, offline);
+                            OpenRewriteModel model = OpenRewriteModelBuilder.forProjectDirectory(tempDirectory.resolve(sourceFile.getSourcePath()).getParent().toFile(), null, initScriptContents);
                             org.openrewrite.gradle.toolingapi.GradleSettings rawSettings = model.gradleSettings();
                             if (rawSettings != null) {
                                 GradleSettings gradleSettings = org.openrewrite.gradle.toolingapi.GradleSettings.toMarker(rawSettings);
                                 sourceFiles.set(i, sourceFile.withMarkers(sourceFile.getMarkers().add(gradleSettings)));
                             }
                         } else if (sourceFile.getSourcePath().endsWith("build.gradle")) {
-                            OpenRewriteModel model = OpenRewriteModelBuilder.forProjectDirectory(projectDir.toFile(), tempDirectory.resolve(sourceFile.getSourcePath()).toFile(), initScriptContents, offline);
+                            OpenRewriteModel model = OpenRewriteModelBuilder.forProjectDirectory(projectDir.toFile(), tempDirectory.resolve(sourceFile.getSourcePath()).toFile(), initScriptContents);
                             GradleProject gradleProject = org.openrewrite.gradle.toolingapi.GradleProject.toMarker(model.gradleProject());
                             allRepositories.addAll(gradleProject.getMavenRepositories());
                             allBuildscriptRepositories.addAll(gradleProject.getBuildscript().getMavenRepositories());
@@ -178,10 +174,6 @@ public class Assertions {
 
     public static UncheckedConsumer<List<SourceFile>> withToolingApi() {
         return withToolingApi((GradleWrapper) null, null);
-    }
-
-    public static UncheckedConsumer<List<SourceFile>> withOfflineToolingApi() {
-        return withToolingApi((GradleWrapper) null, null, true);
     }
 
     private static void deleteDirectory(File directoryToBeDeleted) {

--- a/model/src/main/java/org/openrewrite/gradle/toolingapi/OpenRewriteModelBuilder.java
+++ b/model/src/main/java/org/openrewrite/gradle/toolingapi/OpenRewriteModelBuilder.java
@@ -38,21 +38,9 @@ public class OpenRewriteModelBuilder {
      * Build an OpenRewriteModel for a project directory, using the default Gradle init script bundled within this jar.
      * The included init script accesses public artifact repositories (Maven Central, Nexus Snapshots) to be able to
      * download rewrite dependencies, so public repositories must be accessible for this to work.
-     * @see #forProjectDirectory(File, File, String, boolean)
      */
     public static OpenRewriteModel forProjectDirectory(File projectDir, @Nullable File buildFile) throws IOException {
-        return forProjectDirectory(projectDir, buildFile, null, false);
-    }
-
-    /**
-     * <b></b>Warning: This API is likely to change over time without notice</b>
-     * Build an OpenRewriteModel for a project directory, using the default Gradle init script bundled within this jar.
-     * The included init script accesses public artifact repositories (Maven Central, Nexus Snapshots) to be able to
-     * download rewrite dependencies, so public repositories must be accessible for this to work.
-     * @see #forProjectDirectory(File, File, String, boolean)
-     */
-    public static OpenRewriteModel forProjectDirectory(File projectDir, @Nullable File buildFile, @Nullable String initScript) throws IOException {
-        return forProjectDirectory(projectDir, buildFile, initScript, false);
+        return forProjectDirectory(projectDir, buildFile, null);
     }
 
     /**
@@ -87,7 +75,7 @@ public class OpenRewriteModelBuilder {
      * }
      * </pre>
      */
-    public static OpenRewriteModel forProjectDirectory(File projectDir, @Nullable File buildFile, @Nullable String initScript, boolean offline) throws IOException {
+    public static OpenRewriteModel forProjectDirectory(File projectDir, @Nullable File buildFile, @Nullable String initScript) throws IOException {
         DefaultGradleConnector connector = (DefaultGradleConnector)GradleConnector.newConnector();
         if (Files.exists(projectDir.toPath().resolve("gradle/wrapper/gradle-wrapper.properties"))) {
             connector.useBuildDistribution();
@@ -103,11 +91,6 @@ public class OpenRewriteModelBuilder {
         arguments.add("--init-script");
         Path init = projectDir.toPath().resolve("openrewrite-tooling.gradle").toAbsolutePath();
         arguments.add(init.toString());
-
-        if (offline) {
-            arguments.add("--offline");
-        }
-
         try (ProjectConnection connection = connector.connect()) {
             ModelBuilder<OpenRewriteModel> customModelBuilder = connection.model(OpenRewriteModel.class);
             try {


### PR DESCRIPTION
**What**
- Reverts openrewrite/rewrite-gradle-tooling-model#31

**Why**:
- Nothing wrong with it. But this functionality turned out not needed any more.
- Thus reverting just to simplify the code.