### PR TITLE
Adding support for withToolingApiUsingModulesCaching

### DIFF
--- a/model/src/main/java/org/openrewrite/gradle/toolingapi/Assertions.java
+++ b/model/src/main/java/org/openrewrite/gradle/toolingapi/Assertions.java
@@ -15,6 +15,7 @@
  */
 package org.openrewrite.gradle.toolingapi;
 
+import io.micrometer.core.instrument.util.IOUtils;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.InMemoryExecutionContext;
 import org.openrewrite.SourceFile;
@@ -31,6 +32,7 @@ import org.opentest4j.TestAbortedException;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -174,6 +176,21 @@ public class Assertions {
 
     public static UncheckedConsumer<List<SourceFile>> withToolingApi() {
         return withToolingApi((GradleWrapper) null, null);
+    }
+
+    public static UncheckedConsumer<List<SourceFile>> withToolingApiUsingModulesCaching() {
+        try {
+            final String initScriptContents;
+            try (InputStream is = Assertions.class.getResourceAsStream("/init-with-modules-caching.gradle")) {
+                if (is == null) {
+                    throw new IllegalStateException("Expected to find init-with-modules-caching.gradle on the classpath");
+                }
+                initScriptContents = IOUtils.toString(is);
+            }
+            return withToolingApi((GradleWrapper) null, initScriptContents);
+        } catch (IOException e) {
+            throw new TestAbortedException("Failed to load Gradle Init script", e);
+        }
     }
 
     private static void deleteDirectory(File directoryToBeDeleted) {

--- a/model/src/main/java/org/openrewrite/gradle/toolingapi/Assertions.java
+++ b/model/src/main/java/org/openrewrite/gradle/toolingapi/Assertions.java
@@ -181,9 +181,9 @@ public class Assertions {
     public static UncheckedConsumer<List<SourceFile>> withToolingApiUsingModulesCaching() {
         try {
             final String initScriptContents;
-            try (InputStream is = Assertions.class.getResourceAsStream("/init-with-modules-caching.gradle")) {
+            try (InputStream is = Assertions.class.getResourceAsStream("/init-with-5-minutes-modules-caching.gradle")) {
                 if (is == null) {
-                    throw new IllegalStateException("Expected to find init-with-modules-caching.gradle on the classpath");
+                    throw new IllegalStateException("Expected to find init-with-5-minutes-modules-caching.gradle on the classpath");
                 }
                 initScriptContents = IOUtils.toString(is);
             }

--- a/model/src/main/resources/init-with-5-minutes-modules-caching.gradle
+++ b/model/src/main/resources/init-with-5-minutes-modules-caching.gradle
@@ -20,6 +20,13 @@ initscript {
         mavenCentral()
     }
 
+    configurations.all {
+        resolutionStrategy {
+            cacheChangingModulesFor 5, 'minutes'
+            cacheDynamicVersionsFor 5, 'minutes'
+        }
+    }
+
     dependencies {
         classpath 'org.openrewrite.gradle.tooling:plugin:latest.integration'
         classpath 'org.openrewrite:rewrite-maven:latest.integration'

--- a/model/src/main/resources/init-with-modules-caching.gradle
+++ b/model/src/main/resources/init-with-modules-caching.gradle
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+initscript {
+    repositories {
+        mavenLocal()
+        maven{ url = uri("https://oss.sonatype.org/content/repositories/snapshots") }
+        mavenCentral()
+    }
+
+    dependencies {
+        classpath 'org.openrewrite.gradle.tooling:plugin:latest.integration'
+        classpath 'org.openrewrite:rewrite-maven:latest.integration'
+    }
+}
+
+allprojects {
+    apply plugin: org.openrewrite.gradle.toolingapi.ToolingApiOpenRewriteModelPlugin
+}


### PR DESCRIPTION
## What's changed?
Adding support for `Assertions.withToolingApiUsingModulesCaching` - a way of running tests which use:
```
            cacheChangingModulesFor 5, 'minutes'
            cacheDynamicVersionsFor 5, 'minutes'
```
Gradle init script settings.
instead of `0.seconds` which is what we have now in `withToolingApi`.

BTW, the `0.seconds` setting has been added in https://github.com/openrewrite/rewrite-gradle-tooling-model/commit/57828d2730ea58a70e4ce5dd5120e8c0f35d8d58. I fail to have a context for this change, so leaving these as the default mode.

The value of 5 minutes has been picked using common sense. Should be enough not to cause re-downloading of dependencies in every single test case (which we have hundreds of) and at the same time 5 minutes sounds like good enough value not to have stale dependencies. The Gradle default for both of these settings is 24 hours and I can imagine that might be too much in a project relying on snapshots versions a lot. Like we do.

## What's your motivation?
So that we can use this mode in `rewrite-gradle` tests in the main openrewrite project.
And hopefully get a speed-up in test execution.
