### PR TITLE
Add the gradleProject marker to the lock file like the parser plugin would

### DIFF
--- a/model/src/main/java/org/openrewrite/gradle/toolingapi/Assertions.java
+++ b/model/src/main/java/org/openrewrite/gradle/toolingapi/Assertions.java
@@ -17,6 +17,7 @@ package org.openrewrite.gradle.toolingapi;
 
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.PathUtils;
 import org.openrewrite.SourceFile;
 import org.openrewrite.gradle.UpdateGradleWrapper;
 import org.openrewrite.gradle.marker.GradleBuildscript;
@@ -39,10 +40,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.nio.file.attribute.PosixFilePermission;
-import java.util.ArrayList;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
@@ -139,7 +137,7 @@ public class Assertions {
                     Set<org.openrewrite.maven.tree.MavenRepository> allRepositories = new LinkedHashSet<>();
                     Set<org.openrewrite.maven.tree.MavenRepository> allBuildscriptRepositories = new LinkedHashSet<>();
                     boolean freestandingScriptFound = false;
-                    GradleProject gradleProject = null;
+                    Map<String, GradleProject> gradleProjects = new HashMap<>();
                     for (int i = 0; i < sourceFiles.size(); i++) {
                         SourceFile sourceFile = sourceFiles.get(i);
                         if (sourceFile.getSourcePath().endsWith("settings.gradle") || sourceFile.getSourcePath().endsWith("settings.gradle.kts")) {
@@ -151,19 +149,21 @@ public class Assertions {
                             }
                         } else if (sourceFile.getSourcePath().endsWith("build.gradle") || sourceFile.getSourcePath().endsWith("build.gradle.kts")) {
                             OpenRewriteModel model = OpenRewriteModelBuilder.forProjectDirectory(projectDir.toFile(), tempDirectory.resolve(sourceFile.getSourcePath()).toFile(), initScriptContents);
-                            gradleProject = org.openrewrite.gradle.toolingapi.GradleProject.toMarker(model.gradleProject());
+                            GradleProject gradleProject = org.openrewrite.gradle.toolingapi.GradleProject.toMarker(model.gradleProject());
                             allRepositories.addAll(gradleProject.getMavenRepositories());
                             allBuildscriptRepositories.addAll(gradleProject.getBuildscript().getMavenRepositories());
                             sourceFiles.set(i, sourceFile.withMarkers(sourceFile.getMarkers().add(gradleProject)));
+                            gradleProjects.put(getDirectory(sourceFile), org.openrewrite.gradle.toolingapi.GradleProject.toMarker(model.gradleProject()));
                         } else if (sourceFile.getSourcePath().toString().endsWith(".gradle") || sourceFile.getSourcePath().toString().endsWith(".gradle.kts")) {
                             freestandingScriptFound = true;
                         }
                     }
-                    if (gradleProject != null) {
-                        for (int i = 0; i < sourceFiles.size(); i++) {
-                            SourceFile sourceFile = sourceFiles.get(i);
-                            if (sourceFile.getSourcePath().endsWith("gradle.lockfile") || sourceFile.getSourcePath().endsWith("buildscript-gradle.lockfile")) {
-                                sourceFiles.set(i, sourceFile.withMarkers(sourceFile.getMarkers().add(gradleProject)));
+                    for (int i = 0; i < sourceFiles.size(); i++) {
+                        SourceFile sourceFile = sourceFiles.get(i);
+                        if (sourceFile.getSourcePath().endsWith("gradle.lockfile") || sourceFile.getSourcePath().endsWith("buildscript-gradle.lockfile")) {
+                            GradleProject project = gradleProjects.get(getDirectory(sourceFile));
+                            if (project != null) {
+                                sourceFiles.set(i, sourceFile.withMarkers(sourceFile.getMarkers().add(project)));
                             }
                         }
                     }
@@ -216,5 +216,14 @@ public class Assertions {
         }
         //noinspection ResultOfMethodCallIgnored
         directoryToBeDeleted.delete();
+    }
+
+    private static String getDirectory(SourceFile file) {
+        Path sourcePath = file.getSourcePath();
+        Path parent = sourcePath.getParent();
+        if (parent != null) {
+            return parent.toString();
+        }
+        return "";
     }
 }

--- a/model/src/test/java/org/openrewrite/gradle/toolingapi/AssertionsTest.java
+++ b/model/src/test/java/org/openrewrite/gradle/toolingapi/AssertionsTest.java
@@ -24,6 +24,8 @@ import java.net.URI;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.gradle.Assertions.buildGradle;
+import static org.openrewrite.gradle.Assertions.settingsGradle;
+import static org.openrewrite.test.SourceSpecs.text;
 
 class AssertionsTest implements RewriteTest {
 
@@ -69,24 +71,24 @@ class AssertionsTest implements RewriteTest {
                   maven{ url = uri("https://oss.sonatype.org/content/repositories/snapshots") }
                   mavenCentral()
               }
-          
+
               configurations.all{
                   resolutionStrategy{
                       cacheChangingModulesFor 0, 'seconds'
                       cacheDynamicVersionsFor 0, 'seconds'
                   }
               }
-          
+
               dependencies{
                   classpath 'org.openrewrite.gradle.tooling:plugin:latest.integration'
                   classpath 'org.openrewrite:rewrite-maven:latest.integration'
               }
           }
-          
+
           allprojects{
               apply plugin: org.openrewrite.gradle.toolingapi.ToolingApiOpenRewriteModelPlugin
           }
-          
+
           """;
         GradleWrapper gradleWrapper = GradleWrapper.create(URI.create("https://services.gradle.org/distributions/gradle-8.6-bin.zip"), null);
         rewriteRun(
@@ -100,6 +102,76 @@ class AssertionsTest implements RewriteTest {
               """,
             spec -> spec.afterRecipe(cu -> assertThat(cu.getMarkers().findFirst(GradleProject.class)).isPresent())
           )
+        );
+    }
+
+    @Test
+    void withLockFile() {
+        rewriteRun(
+                spec -> spec.beforeRecipe(Assertions.withToolingApi()),
+                //language=groovy
+                buildGradle(
+                        """
+                          plugins {
+                              id 'java'
+                          }
+                          """,
+                        spec -> spec.afterRecipe(cu -> assertThat(cu.getMarkers().findFirst(GradleProject.class)).isPresent())
+                ), text(
+                         """
+                          # This is a Gradle generated file for dependency locking.
+                          # Manual edits can break the build and are not advised.
+                          # This file is expected to be part of source control.
+                          empty=
+                          """,
+                        spec -> spec
+                                .path("gradle.lockfile")
+                                .afterRecipe(cu -> assertThat(cu.getMarkers().findFirst(GradleProject.class)).isPresent())
+                )
+        );
+    }
+
+    @Test
+    void multimoduleLockFiles() {
+        rewriteRun(
+                spec -> spec.beforeRecipe(Assertions.withToolingApi()),
+                //language=groovy
+                settingsGradle("""
+                        rootProject.name = 'test'
+                        include 'subproject1', 'subproject2'
+                        """),
+                buildGradle(
+                        """
+                          plugins {
+                              id 'java'
+                          }
+                          """,
+                        spec -> spec
+                                .path("build.gradle")
+                                .afterRecipe(cu -> assertThat(cu.getMarkers().findFirst(GradleProject.class)).isPresent())
+                ), text(
+                        """
+                         # This is a Gradle generated file for dependency locking.
+                         # Manual edits can break the build and are not advised.
+                         # This file is expected to be part of source control.
+                         empty=
+                         """,
+                        spec -> spec
+                                .path("subproject1/gradle.lockfile")
+                                .afterRecipe(cu -> assertThat(cu.getMarkers().findFirst(GradleProject.class)).isPresent())
+                ), text(
+                        """
+                         # This is a Gradle generated file for dependency locking.
+                         # Manual edits can break the build and are not advised.
+                         # This file is expected to be part of source control.
+                         empty=
+                         """,
+                        spec -> spec
+                                .path("subproject2/gradle.lockfile")
+                                .afterRecipe(cu -> assertThat(cu.getMarkers().findFirst(GradleProject.class)).isPresent())
+                ),
+                buildGradle("", spec -> spec.path("subproject1/build.gradle")),
+                buildGradle("", spec -> spec.path("subproject2/build.gradle"))
         );
     }
 }

--- a/model/src/test/java/org/openrewrite/gradle/toolingapi/AssertionsTest.java
+++ b/model/src/test/java/org/openrewrite/gradle/toolingapi/AssertionsTest.java
@@ -21,6 +21,7 @@ import org.openrewrite.gradle.util.GradleWrapper;
 import org.openrewrite.test.RewriteTest;
 
 import java.net.URI;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.gradle.Assertions.buildGradle;
@@ -148,7 +149,11 @@ class AssertionsTest implements RewriteTest {
                           """,
                         spec -> spec
                                 .path("build.gradle")
-                                .afterRecipe(cu -> assertThat(cu.getMarkers().findFirst(GradleProject.class)).isPresent())
+                                .afterRecipe(cu -> {
+                                    Optional<GradleProject> gp = cu.getMarkers().findFirst(GradleProject.class);
+                                    assertThat(gp).isPresent();
+                                    assertThat(gp.get().getPath()).isEqualTo(":");
+                                })
                 ), text(
                         """
                          # This is a Gradle generated file for dependency locking.
@@ -158,7 +163,11 @@ class AssertionsTest implements RewriteTest {
                          """,
                         spec -> spec
                                 .path("subproject1/gradle.lockfile")
-                                .afterRecipe(cu -> assertThat(cu.getMarkers().findFirst(GradleProject.class)).isPresent())
+                                .afterRecipe(cu -> {
+                                    Optional<GradleProject> gp = cu.getMarkers().findFirst(GradleProject.class);
+                                    assertThat(gp).isPresent();
+                                    assertThat(gp.get().getPath()).isEqualTo(":subproject1");
+                                })
                 ), text(
                         """
                          # This is a Gradle generated file for dependency locking.
@@ -168,7 +177,11 @@ class AssertionsTest implements RewriteTest {
                          """,
                         spec -> spec
                                 .path("subproject2/gradle.lockfile")
-                                .afterRecipe(cu -> assertThat(cu.getMarkers().findFirst(GradleProject.class)).isPresent())
+                                .afterRecipe(cu -> {
+                                    Optional<GradleProject> gp = cu.getMarkers().findFirst(GradleProject.class);
+                                    assertThat(gp).isPresent();
+                                    assertThat(gp.get().getPath()).isEqualTo(":subproject2");
+                                })
                 ),
                 buildGradle("", spec -> spec.path("subproject1/build.gradle")),
                 buildGradle("", spec -> spec.path("subproject2/build.gradle"))


### PR DESCRIPTION
see: 
- https://github.com/openrewrite/rewrite-gradle-plugin/pull/380

We want to do the equivalent in the tests when using `withToolingApi()`