### PR TITLE
Fixed the multiple GradleMarkers being present if multiple calls to withToolingApi

### DIFF
--- a/model/src/main/java/org/openrewrite/gradle/toolingapi/Assertions.java
+++ b/model/src/main/java/org/openrewrite/gradle/toolingapi/Assertions.java
@@ -17,7 +17,6 @@ package org.openrewrite.gradle.toolingapi;
 
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.InMemoryExecutionContext;
-import org.openrewrite.PathUtils;
 import org.openrewrite.SourceFile;
 import org.openrewrite.gradle.UpdateGradleWrapper;
 import org.openrewrite.gradle.marker.GradleBuildscript;
@@ -145,14 +144,14 @@ public class Assertions {
                             org.openrewrite.gradle.toolingapi.GradleSettings rawSettings = model.gradleSettings();
                             if (rawSettings != null) {
                                 GradleSettings gradleSettings = org.openrewrite.gradle.toolingapi.GradleSettings.toMarker(rawSettings);
-                                sourceFiles.set(i, sourceFile.withMarkers(sourceFile.getMarkers().add(gradleSettings)));
+                                sourceFiles.set(i, sourceFile.withMarkers(sourceFile.getMarkers().setByType(gradleSettings)));
                             }
                         } else if (sourceFile.getSourcePath().endsWith("build.gradle") || sourceFile.getSourcePath().endsWith("build.gradle.kts")) {
                             OpenRewriteModel model = OpenRewriteModelBuilder.forProjectDirectory(projectDir.toFile(), tempDirectory.resolve(sourceFile.getSourcePath()).toFile(), initScriptContents);
                             GradleProject gradleProject = org.openrewrite.gradle.toolingapi.GradleProject.toMarker(model.gradleProject());
                             allRepositories.addAll(gradleProject.getMavenRepositories());
                             allBuildscriptRepositories.addAll(gradleProject.getBuildscript().getMavenRepositories());
-                            sourceFiles.set(i, sourceFile.withMarkers(sourceFile.getMarkers().add(gradleProject)));
+                            sourceFiles.set(i, sourceFile.withMarkers(sourceFile.getMarkers().setByType(gradleProject)));
                             gradleProjects.put(getDirectory(sourceFile), org.openrewrite.gradle.toolingapi.GradleProject.toMarker(model.gradleProject()));
                         } else if (sourceFile.getSourcePath().toString().endsWith(".gradle") || sourceFile.getSourcePath().toString().endsWith(".gradle.kts")) {
                             freestandingScriptFound = true;
@@ -163,7 +162,7 @@ public class Assertions {
                         if (sourceFile.getSourcePath().endsWith("gradle.lockfile") || sourceFile.getSourcePath().endsWith("buildscript-gradle.lockfile")) {
                             GradleProject project = gradleProjects.get(getDirectory(sourceFile));
                             if (project != null) {
-                                sourceFiles.set(i, sourceFile.withMarkers(sourceFile.getMarkers().add(project)));
+                                sourceFiles.set(i, sourceFile.withMarkers(sourceFile.getMarkers().setByType(project)));
                             }
                         }
                     }

--- a/model/src/test/java/org/openrewrite/gradle/toolingapi/AssertionsTest.java
+++ b/model/src/test/java/org/openrewrite/gradle/toolingapi/AssertionsTest.java
@@ -107,6 +107,33 @@ class AssertionsTest implements RewriteTest {
     }
 
     @Test
+    void multipleToolingApiCallsAddSingleMarker() {
+        rewriteRun(
+                spec -> spec.beforeRecipe(Assertions.withToolingApi())
+                        .beforeRecipe(Assertions.withToolingApi()),
+                //language=groovy
+                buildGradle(
+                        """
+                          plugins {
+                              id 'java'
+                          }
+                          """,
+                        spec -> spec.afterRecipe(cu -> assertThat(cu.getMarkers().findAll(GradleProject.class)).hasSize(1))
+                ), text(
+                        """
+                         # This is a Gradle generated file for dependency locking.
+                         # Manual edits can break the build and are not advised.
+                         # This file is expected to be part of source control.
+                         empty=
+                         """,
+                        spec -> spec
+                                .path("gradle.lockfile")
+                                .afterRecipe(cu -> assertThat(cu.getMarkers().findAll(GradleProject.class)).hasSize(1))
+                )
+        );
+    }
+
+    @Test
     void withLockFile() {
         rewriteRun(
                 spec -> spec.beforeRecipe(Assertions.withToolingApi()),


### PR DESCRIPTION
## What's changed?
We were adding 2 markers if the call was made twice (eg. default and in test).
I though about not doing the block if a marker is already calculated earlier but this was the easiets/lowest impact change for a behavior that should almost never occur. 

### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
