### PR TITLE
Add support for using version catalogs in tests

### DIFF
--- a/model/build.gradle.kts
+++ b/model/build.gradle.kts
@@ -17,6 +17,7 @@ dependencies {
     compileOnly("org.openrewrite:rewrite-groovy:latest.integration")
     compileOnly("org.openrewrite:rewrite-kotlin:latest.integration")
     compileOnly("org.openrewrite:rewrite-properties:latest.integration")
+    compileOnly("org.openrewrite:rewrite-toml:latest.integration")
 
     testImplementation("org.openrewrite:rewrite-test:latest.integration")
     testImplementation("org.openrewrite:rewrite-gradle:latest.integration") {

--- a/model/src/main/java/org/openrewrite/gradle/toolingapi/Assertions.java
+++ b/model/src/main/java/org/openrewrite/gradle/toolingapi/Assertions.java
@@ -29,6 +29,7 @@ import org.openrewrite.marker.OperatingSystemProvenance;
 import org.openrewrite.properties.tree.Properties;
 import org.openrewrite.test.UncheckedConsumer;
 import org.openrewrite.text.PlainText;
+import org.openrewrite.toml.tree.Toml;
 import org.opentest4j.TestAbortedException;
 
 import java.io.File;
@@ -98,6 +99,16 @@ public class Assertions {
                                 }
                                 Files.createDirectories(gradleProperties.getParent());
                                 Files.write(gradleProperties, f.printAllAsBytes());
+                            }
+                        } else if (sourceFile instanceof Toml.Document) {
+                            Toml.Document d = (Toml.Document) sourceFile;
+                            if (d.getSourcePath().startsWith("gradle/") && d.getSourcePath().toString().endsWith(".versions.toml")) {
+                                Path versionCatalog = tempDirectory.resolve(d.getSourcePath());
+                                if (!tempDirectory.equals(versionCatalog.getParent()) && tempDirectory.equals(versionCatalog.getParent().getParent())) {
+                                    projectDir = versionCatalog.getParent();
+                                }
+                                Files.createDirectories(versionCatalog.getParent());
+                                Files.write(versionCatalog, d.printAllAsBytes());
                             }
                         } else if (sourceFile instanceof PlainText) {
                             PlainText plainText = (PlainText) sourceFile;


### PR DESCRIPTION
## What's changed?
Add support for writing out version catalogs, such that they can be used within unit tests.

## What's your motivation?
Enable more snippets that are parseable in tests.

## Anything in particular you'd like reviewers to focus on?
Nothing in particular

## Anyone you would like to review specifically?
Anybody

## Have you considered any alternatives or workarounds?
N/A

## Any additional context
I noticed that version catalogs weren't yet supported in test cases as part of verifying the test snippets as part of https://github.com/openrewrite/rewrite/pull/5574. Conventionally, I've limited version catalogs to the format included here of `gradle/*.versions.toml`, however version catalogs can technically carry any file name. This just seemed like a good middle ground though from a conventional standpoint.

See [Version Catalogs](https://docs.gradle.org/current/userguide/version_catalogs.html) for more information.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
